### PR TITLE
Fix hydration error and image priority

### DIFF
--- a/src/components/footer/footer-navigation.tsx
+++ b/src/components/footer/footer-navigation.tsx
@@ -41,18 +41,18 @@ interface NavigationItemProps {
 
 const NavigationItem: FC<NavigationItemProps> = ({ label, path }) => {
   return (
-    <Link href={path} passHref>
-      <MuiLink
-        underline="hover"
-        sx={{
-          display: 'block',
-          mb: 1,
-          color: 'primary.contrastText',
-        }}
-      >
-        {label}
-      </MuiLink>
-    </Link>
+    <MuiLink
+      component={Link}
+      href={path}
+      underline="hover"
+      sx={{
+        display: 'block',
+        mb: 1,
+        color: 'primary.contrastText',
+      }}
+    >
+      {label}
+    </MuiLink>
   )
 }
 

--- a/src/components/home/hero.tsx
+++ b/src/components/home/hero.tsx
@@ -215,7 +215,7 @@ const HomeHero: FC = () => {
               </Box>
             </Box>
             <Box sx={{ lineHeight: 0 }}>
-              <Image src="/images/home-hero.jpg" width={775} height={787} alt="Hero img" />
+              <Image src="/images/home-hero.jpg" width={775} height={787} alt="Hero img" priority />
             </Box>
           </Grid>
         </Grid>

--- a/src/components/navigation/navigation.data.ts
+++ b/src/components/navigation/navigation.data.ts
@@ -11,10 +11,10 @@ export const navigations: Navigation[] = [
   },
   {
     label: 'Testimonial',
-    path: 'testimonial', // '/testimonial',
+    path: '/testimonial',
   },
   {
     label: 'Mentor',
-    path: 'mentors', // '/mentors',
+    path: '/mentors',
   },
 ]


### PR DESCRIPTION
Fixes React hydration errors and Next.js warnings by standardizing link paths and image priority.

The `href` mismatch hydration error was caused by inconsistent paths (e.g., "testimonial" vs. "/testimonial"). This is resolved by ensuring all navigation paths start with a leading slash. The Next.js Image LCP warning is addressed by adding the `priority` prop to the hero image. Additionally, the `Next/Link` component usage was updated to the modern `component={Link}` pattern, removing the deprecated `passHref` prop.

---
<a href="https://cursor.com/background-agent?bcId=bc-c864ec29-e747-4d3e-b92c-1c72964d023a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c864ec29-e747-4d3e-b92c-1c72964d023a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>