### PR TITLE
Fix github pages ui display issues

### DIFF
--- a/src/components/course/course-card-item.tsx
+++ b/src/components/course/course-card-item.tsx
@@ -6,6 +6,7 @@ import Typography from '@mui/material/Typography'
 import IconButton, { iconButtonClasses } from '@mui/material/IconButton'
 import ArrowForward from '@mui/icons-material/ArrowForward'
 import { Course } from '@/interfaces/course'
+import { getImagePath } from '@/utils/paths'
 
 interface Props {
   item: Course
@@ -43,7 +44,7 @@ const CourseCardItem: FC<Props> = ({ item }) => {
             mb: 2,
           }}
         >
-          <Image src={item.cover} width={760} height={760} alt={'Course ' + item.id} />
+          <Image src={getImagePath(item.cover)} width={760} height={760} alt={'Course ' + item.id} />
         </Box>
         <Box sx={{ mb: 2 }}>
           <Typography component="h2" variant="h5" sx={{ mb: 2, height: 56, overflow: 'hidden', fontSize: '1.2rem' }}>

--- a/src/components/home/feature.tsx
+++ b/src/components/home/feature.tsx
@@ -8,7 +8,7 @@ import Typography from '@mui/material/Typography'
 import CircularProgress from '@mui/material/CircularProgress'
 import LinearProgress, { linearProgressClasses } from '@mui/material/LinearProgress'
 import { data } from './feature.data'
-import { getAssetPath } from '@/utils/paths'
+import { getImagePath } from '@/utils/paths'
 
 interface LinearProgressProps {
   order: number
@@ -43,7 +43,7 @@ const HomeFeature: FC = () => {
         <Grid container spacing={3}>
           <Grid item xs={12} md={5}>
             <Box sx={{ position: 'relative' }}>
-              <Image src={getAssetPath("/images/home-feature.png")} width={650} height={678} quality={97} alt="Feature img" />
+              <Image src={getImagePath("/images/home-feature.png")} width={650} height={678} quality={97} alt="Feature img" />
               <Box
                 sx={{
                   position: 'absolute',
@@ -176,7 +176,7 @@ const HomeFeature: FC = () => {
                   }}
                 >
                   {/* eslint-disable-next-line @next/next/no-img-element */}
-                  <img src={getAssetPath("/images/headline-curve.svg")} alt="Headline curve" />
+                  <img src={getImagePath("/images/headline-curve.svg")} alt="Headline curve" />
                 </Box>
               </Typography>
               Enjoyable

--- a/src/components/home/hero.tsx
+++ b/src/components/home/hero.tsx
@@ -8,7 +8,7 @@ import Dialog from '@mui/material/Dialog'
 import IconButton from '@mui/material/IconButton'
 import CloseIcon from '@mui/icons-material/Close'
 import { StyledButton } from '@/components/styled-button'
-import { getAssetPath } from '@/utils/paths'
+import { getImagePath } from '@/utils/paths'
 
 interface Exp {
   label: string
@@ -103,10 +103,10 @@ const HomeHero: FC = () => {
                         top: { xs: 16, md: 24 },
                         left: 2,
                         transform: 'rotate(3deg)',
-                        '& img': { width: { xs: 120, md: 160 }, height: 'auto' },
+                        zIndex: 1,
                       }}
                     >
-                      <img src={getAssetPath("/images/headline-curve.svg")} alt="Headline curve" />
+                      <Image src={getImagePath("/images/headline-curve.svg")} alt="Headline curve" width={160} height={40} />
                     </Box>
                   </Typography>
                   your{' '}
@@ -122,6 +122,7 @@ const HomeHero: FC = () => {
                         right: -18,
                         width: { xs: 20, md: 28 },
                         height: 'auto',
+                        zIndex: 2,
                       },
                     }}
                   >
@@ -201,7 +202,7 @@ const HomeHero: FC = () => {
                   '& img': { width: '32px !important', height: 'auto' },
                 }}
               >
-                                  <Image src={getAssetPath("/images/certificate.png")} alt="Certificate icon" width={50} height={50} quality={97} />
+                                  <Image src={getImagePath("/images/certificate.png")} alt="Certificate icon" width={50} height={50} quality={97} />
               </Box>
               <Box>
                 <Typography
@@ -216,7 +217,7 @@ const HomeHero: FC = () => {
               </Box>
             </Box>
             <Box sx={{ lineHeight: 0 }}>
-              <Image src={getAssetPath("/images/home-hero.jpg")} width={775} height={787} alt="Hero img" />
+              <Image src={getImagePath("/images/home-hero.jpg")} width={775} height={787} alt="Hero img" />
             </Box>
           </Grid>
         </Grid>

--- a/src/components/home/testimonial.tsx
+++ b/src/components/home/testimonial.tsx
@@ -8,7 +8,7 @@ import Typography from '@mui/material/Typography'
 import IconButton from '@mui/material/IconButton'
 import { styled } from '@mui/material/styles'
 import IconArrowBack from '@mui/icons-material/ArrowBack'
-import { getAssetPath } from '@/utils/paths'
+import { getImagePath } from '@/utils/paths'
 import IconArrowForward from '@mui/icons-material/ArrowForward'
 
 import { TestimonialItem } from '@/components/testimonial'
@@ -100,7 +100,7 @@ const HomeTestimonial: FC = () => {
                   }}
                 >
                   {/* eslint-disable-next-line @next/next/no-img-element */}
-                  <img src={getAssetPath("/images/headline-curve.svg")} alt="Headline curve" />
+                                      <img src={getImagePath("/images/headline-curve.svg")} alt="Headline curve" />
                 </Box>
               </Typography>
               Say
@@ -116,7 +116,7 @@ const HomeTestimonial: FC = () => {
           </Grid>
           <Grid item xs={12} md={6} sx={{ display: { xs: 'none', md: 'block' } }}>
             <Box sx={{ width: { xs: '100%', md: '90%' } }}>
-              <Image src={getAssetPath("/images/home-testimonial.png")} width={520} height={540} quality={97} alt="Testimonial img" />
+                              <Image src={getImagePath("/images/home-testimonial.png")} width={520} height={540} quality={97} alt="Testimonial img" />
             </Box>
           </Grid>
         </Grid>

--- a/src/components/mentor/mentor-card-item.tsx
+++ b/src/components/mentor/mentor-card-item.tsx
@@ -4,6 +4,7 @@ import Box from '@mui/material/Box'
 import Typography from '@mui/material/Typography'
 
 import { Mentor } from '@/interfaces/mentor'
+import { getImagePath } from '@/utils/paths'
 
 interface Props {
   item: Mentor
@@ -37,7 +38,7 @@ const MentorCardItem: FC<Props> = ({ item }) => {
             mb: 2,
           }}
         >
-          <Image src={item.photo as string} width={570} height={427} alt={'Mentor ' + item.id} />
+          <Image src={getImagePath(item.photo as string)} width={570} height={427} alt={'Mentor ' + item.id} />
         </Box>
         <Box sx={{ mb: 2 }}>
           <Typography component="h2" variant="h4" sx={{ fontSize: '1.4rem' }}>
@@ -49,7 +50,7 @@ const MentorCardItem: FC<Props> = ({ item }) => {
           </Typography>
           <Box sx={{ '& img': { height: 26 } }}>
             {/* eslint-disable-next-line */}
-            <img src={item.company?.logo} alt={item.company?.name + ' logo'} />
+            <img src={getImagePath(item.company?.logo || '')} alt={item.company?.name + ' logo'} />
           </Box>
         </Box>
       </Box>

--- a/src/components/navigation/navigation.tsx
+++ b/src/components/navigation/navigation.tsx
@@ -2,7 +2,7 @@ import React, { FC } from 'react'
 import Box from '@mui/material/Box'
 import { Link as ScrollLink } from 'react-scroll'
 import { navigations } from './navigation.data'
-import { getAssetPath } from '@/utils/paths'
+import { getImagePath } from '@/utils/paths'
 
 const Navigation: FC = () => {
   return (
@@ -52,7 +52,7 @@ const Navigation: FC = () => {
             }}
           >
             {/* eslint-disable-next-line */}
-            <img src={getAssetPath("/images/headline-curve.svg")} alt="Headline curve" />
+                            <img src={getImagePath("/images/headline-curve.svg")} alt="Headline curve" />
           </Box>
           {label}
         </Box>

--- a/src/components/testimonial/testimonial-item.tsx
+++ b/src/components/testimonial/testimonial-item.tsx
@@ -3,6 +3,7 @@ import Image from 'next/image'
 import Box from '@mui/material/Box'
 import Typography from '@mui/material/Typography'
 import { Testimonial } from '@/interfaces/testimonial'
+import { getImagePath } from '@/utils/paths'
 
 interface Props {
   item: Testimonial
@@ -44,7 +45,7 @@ const TestimonialItem: FC<Props> = ({ item }) => {
           }}
         >
           <Image
-            src={`/images/avatars/${item.user.photo}`}
+            src={getImagePath(`/images/avatars/${item.user.photo}`)}
             width={100}
             height={100}
             quality={97}

--- a/src/utils/paths.ts
+++ b/src/utils/paths.ts
@@ -18,3 +18,20 @@ export const getAssetPath = (path: string): string => {
   
   return path;
 };
+
+// Simplified asset path function for images
+export const getImagePath = (path: string): string => {
+  // For GitHub Pages, we need to handle the base path correctly
+  if (typeof window !== 'undefined') {
+    const basePath = (window as any).__NEXT_DATA__?.basePath || '';
+    return basePath + path;
+  }
+  
+  const isProduction = process.env.NODE_ENV === 'production';
+  if (isProduction) {
+    const repo = 'SBA';
+    return `/${repo}${path}`;
+  }
+  
+  return path;
+};


### PR DESCRIPTION
Fix UI issues on GitHub Pages by correcting image paths and resolving text overlapping.

The previous `getAssetPath` function caused broken image links on GitHub Pages due to incorrect base path resolution. This PR introduces `getImagePath` to correctly handle image paths and replaces native `<img>` tags with Next.js `Image` component for better performance. Additionally, `z-index` properties were adjusted in the hero section to resolve text overlapping.

---
<a href="https://cursor.com/background-agent?bcId=bc-4ee0ef21-63d6-41c5-8313-e05b40ffd971">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4ee0ef21-63d6-41c5-8313-e05b40ffd971">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>